### PR TITLE
URIParser and removed `transformer.transform` from trainer (as well as refactors)

### DIFF
--- a/lib/news_scraper.rb
+++ b/lib/news_scraper.rb
@@ -2,8 +2,8 @@ require 'httparty'
 require 'yaml'
 
 require 'news_scraper/constants'
+require 'news_scraper/uri_parser'
 require 'news_scraper/active_support_lite/string'
-require 'news_scraper/cli'
 
 require 'news_scraper/errors'
 require 'news_scraper/version'
@@ -15,6 +15,7 @@ require 'news_scraper/extractors/article'
 
 require 'news_scraper/transformers/article'
 
+require 'news_scraper/cli'
 require 'news_scraper/trainer'
 
 module NewsScraper

--- a/lib/news_scraper/cli.rb
+++ b/lib/news_scraper/cli.rb
@@ -83,7 +83,7 @@ module NewsScraper
       ptext = "#{color}#{prefix}#{text}"
       textwidth = printing_width(ptext)
 
-      termwidth = IO.console ? IO.console.winsize[1] : 80
+      termwidth = IO.respond_to?(:console) && IO.console ? IO.console.winsize[1] : 80
       termwidth = 30 if termwidth < 30
 
       if textwidth > termwidth

--- a/lib/news_scraper/trainer/presets_selector.rb
+++ b/lib/news_scraper/trainer/presets_selector.rb
@@ -1,21 +1,21 @@
 module NewsScraper
   module Trainer
     class PresetsSelector
-      def initialize(uri)
-        @uri = uri
+      def initialize(uri:)
+        uri_parser = URIParser.new(uri)
+        @uri = uri_parser.without_scheme
         @scrape_patterns = YAML.load_file(Constants::SCRAPE_PATTERN_FILEPATH)
       end
 
       def select(payload)
         selected_presets = {}
-        all_presets = @scrape_patterns['presets']
 
         CLI.put_header(@uri)
         CLI.log "Fetching information..."
         CLI.put_footer
 
         @scrape_patterns['data_types'].each do |target_data_type|
-          data_type_presets = all_presets[target_data_type]
+          data_type_presets = @scrape_patterns['presets'][target_data_type]
           preset_results = preset_results(payload, data_type_presets, target_data_type)
 
           CLI.put_header("Determining information for #{target_data_type}")

--- a/lib/news_scraper/trainer/uri_trainer.rb
+++ b/lib/news_scraper/trainer/uri_trainer.rb
@@ -3,60 +3,53 @@ module NewsScraper
     class UriTrainer
       def initialize(uri)
         @article_scrape_patterns = YAML.load_file(Constants::SCRAPE_PATTERN_FILEPATH)
-        @data_type = Trainer::PresetsSelector.new(uri)
-
-        @uri = uri
-        @raw_html = Extractors::Article.new(uri: uri).extract
-        @transformer = Transformers::Article.new(
-          uri: uri,
-          payload: @raw_html,
-          scrape_patterns: @article_scrape_patterns
-        )
+        uri_parser = URIParser.new(uri)
+        @uri = uri_parser.without_scheme
+        @root_domain = uri_parser.host
+        @raw_html = Extractors::Article.new(uri: @uri).extract
       end
 
       def train
-        if @article_scrape_patterns['domains'].key?(@transformer.root_domain)
-          @transformer.transform
-        else
+        unless @article_scrape_patterns['domains'].key?(@root_domain)
           CLI.put_header
-          CLI.log("There is no scrape pattern defined for #{@transformer.root_domain}"\
+          CLI.log("There is no scrape pattern defined for #{@root_domain}"\
             " in config/article_scrape_patterns.yml")
-          no_scrape_defined(@transformer.root_domain)
+          no_scrape_defined
         end
       end
 
-      def no_scrape_defined(root_domain)
-        if CLI.confirm("Step through presets for #{root_domain}?")
+      def no_scrape_defined
+        if CLI.confirm("Step through presets for #{@root_domain}?")
           CLI.put_footer
-          selected_presets = @data_type.train(@raw_html)
+          selected_presets = Trainer::PresetsSelector.new(uri: @uri).select(@raw_html)
 
           CLI.put_header('Save preset')
           CLI.log_lines(selected_presets.to_yaml)
-          if CLI.confirm("Save these scrape patterns for #{root_domain}?")
-            save_selected_presets(root_domain, selected_presets)
+          if CLI.confirm("Save these scrape patterns for #{@root_domain}?")
+            save_selected_presets(selected_presets)
           end
         else
-          CLI.log("Ignoring step-through for #{root_domain}", color: '\x1b[31m')
+          CLI.log("Ignoring step-through for #{@root_domain}", color: '\x1b[31m')
         end
 
         CLI.put_footer
       end
 
-      def save_selected_presets(root_domain, selected_presets)
-        save_domain_presets = if @article_scrape_patterns['domains'].key?(root_domain)
-          CLI.log("YAML file already contains scrape pattern for #{root_domain}:")
-          CLI.log_lines(@article_scrape_patterns['domains'][root_domain].to_yaml)
+      def save_selected_presets(selected_presets)
+        save_domain_presets = if @article_scrape_patterns['domains'].key?(@root_domain)
+          CLI.log("YAML file already contains scrape pattern for #{@root_domain}:")
+          CLI.log_lines(@article_scrape_patterns['domains'][@root_domain].to_yaml)
           CLI.confirm("Overwrite?")
         else
           true
         end
 
         if save_domain_presets
-          @article_scrape_patterns['domains'][root_domain] = selected_presets
+          @article_scrape_patterns['domains'][@root_domain] = selected_presets
           File.write('config/article_scrape_patterns.yml', @article_scrape_patterns.to_yaml)
-          CLI.log("Successfully wrote presets for #{root_domain} to config/article_scrape_patterns.yml.")
+          CLI.log("Successfully wrote presets for #{@root_domain} to config/article_scrape_patterns.yml.")
         else
-          CLI.log("Did not write presets for #{root_domain} to file.")
+          CLI.log("Did not write presets for #{@root_domain} to file.")
         end
       end
     end

--- a/lib/news_scraper/transformers/article.rb
+++ b/lib/news_scraper/transformers/article.rb
@@ -7,20 +7,18 @@ module NewsScraper
       attr_reader :uri, :payload
 
       def initialize(uri:, payload:, scrape_details: nil, scrape_patterns: Constants::SCRAPE_PATTERNS)
-        @uri = uri
+        uri_parser = URIParser.new(uri)
+        @uri = uri_parser.without_scheme
+        @root_domain = uri_parser.host
         @payload = payload
         @scrape_patterns = scrape_patterns
         @scrape_details = scrape_details
       end
 
       def transform
-        raise ScrapePatternNotDefined.new(root_domain: root_domain) unless scrape_pattern?
+        raise ScrapePatternNotDefined.new(root_domain: @root_domain) unless scrape_pattern?
 
-        transformed_response.merge(root_domain: root_domain)
-      end
-
-      def root_domain
-        @root_domain ||= uri.downcase.match(/^(?:[\w\d-]+\.)?([\w\d-]+\.\w{2,})/)[1]
+        transformed_response.merge(root_domain: @root_domain)
       end
 
       private
@@ -30,7 +28,7 @@ module NewsScraper
       end
 
       def scrape_details
-        @scrape_details ||= @scrape_patterns['domains'][root_domain]
+        @scrape_details ||= @scrape_patterns['domains'][@root_domain]
       end
 
       def transformed_response

--- a/lib/news_scraper/uri_parser.rb
+++ b/lib/news_scraper/uri_parser.rb
@@ -1,0 +1,15 @@
+module NewsScraper
+  class URIParser
+    def initialize(url)
+      @url = url
+    end
+
+    def without_scheme
+      @url.gsub(%r(^https?://), '')
+    end
+
+    def host
+      without_scheme.downcase.match(/^(?:[\w\d-]+\.)?(?<host>[\w\d-]+\.\w{2,})/)['host']
+    end
+  end
+end

--- a/test/unit/trainers/presets_selector_test.rb
+++ b/test/unit/trainers/presets_selector_test.rb
@@ -21,7 +21,7 @@ module NewsScraper
           'I will provide a pattern using css',
           'skip'
         ]
-        @presets_selector = NewsScraper::Trainer::PresetsSelector.new(@domain)
+        @presets_selector = NewsScraper::Trainer::PresetsSelector.new(uri: @domain)
       end
 
       def test_select_without_preset_results

--- a/test/unit/transformers/article_test.rb
+++ b/test/unit/transformers/article_test.rb
@@ -23,14 +23,4 @@ class ArticleTest < Minitest::Test
     end
     assert_equal unsupported_domain, err.root_domain
   end
-
-  def test_root_domain
-    domain = 'unsupported-domain.com'
-    transformer = NewsScraper::Transformers::Article.new(uri: domain, payload: '')
-    assert_equal domain, transformer.root_domain
-
-    domain_with_path_and_param = 'www.unsupported-domain.com/banana/apple/kiwi?param=1'
-    transformer = NewsScraper::Transformers::Article.new(uri: domain_with_path_and_param, payload: '')
-    assert_equal domain, transformer.root_domain
-  end
 end

--- a/test/unit/uri_parser_test.rb
+++ b/test/unit/uri_parser_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+module NewsScraper
+  class URIParserTest < Minitest::Test
+    def setup
+      url = "https://www.yolo.com/this/is?cool=1"
+      @uri_parser = URIParser.new(url)
+    end
+
+    def test_without_scheme_removes_http_or_https_scheme
+      assert_equal "www.yolo.com/this/is?cool=1", @uri_parser.without_scheme
+    end
+
+    def test_host_returns_the_root_domain
+      assert_equal "yolo.com", @uri_parser.host
+    end
+  end
+end


### PR DESCRIPTION
Wanted to first refactor out this https://github.com/richardwu/news_scraper/compare/uri_parser_and_trainer_refactor_1?expand=1#diff-1ee27f6b90d971e3cdcf966d679cfb11L19 since we don't really need it once we discover that a domain is not in the config file.

Ended up having to refactor and fix a lot of tests because of how much we depended on our private interface.

I think a good next step is to move some of the helper methods (e.g. `no_scrape_defined`, `save_selected_presets`) into private methods and do a full integration test using the public interface(i.e. `UriTrainer#train` and `PresetsSelector.select`) instead. 

cc: @jules2689 
