### PR TITLE
Maintain YAML structure during training

### DIFF
--- a/config/article_scrape_patterns.yml
+++ b/config/article_scrape_patterns.yml
@@ -35,7 +35,7 @@ presets:
       method: css
       pattern: ".vcard .fn"
   body:
-    readability: &readability
+    readability: &readability_body
       method: "readability"
       pattern: ""
   description:
@@ -49,7 +49,7 @@ presets:
     meta: &meta_keywords
       method: "xpath"
       pattern: "//meta[@name='keywords']/@content"
-    article_tag: &article_tag
+    article_tag: &article_tag_keywords
       method: "xpath"
       pattern: "//meta[@property='article:tag']/@content"
   section:
@@ -57,34 +57,34 @@ presets:
       method: "xpath"
       pattern: "//meta[@property='article:section']/@content"
   datetime:
-    article_date_original: &article_date_original
+    article_date_original: &article_date_original_datetime
       method: xpath
       pattern: //meta[@name='article_date_original']/@content
-    article_published_time: &article_published_time
+    article_published_time: &article_published_time_datetime
       method: "xpath"
       pattern: "//meta[@property='article:published_time']/@content"
-    date: &date
+    date: &date_datetime
       method: xpath
       pattern: //meta[@name='date']/@content
-    date_published: &date_published
+    date_published: &date_published_datetime
       method: xpath
-      pattern: //meta[@itemprop='datePublished']/@datetime
-    og_published_time: &og_published_time
+      pattern: //*[@itemprop='datePublished']/@datetime
+    og_published_time: &og_published_time_datetime
       method: xpath
       pattern: //meta[@property='og:published_time']/@content
-    original_publication_date: &original_publication_date
+    original_publication_date: &original_publication_date_datetime
       method: xpath
       pattern: //meta[@name='OriginalPublicationDate']/@content
-    publication_date: &publication_date
+    publication_date: &publication_date_datetime
       method: xpath
       pattern: //meta[@name='publication_date']/@content
-    publish_date: &publish_date
+    publish_date: &publish_date_datetime
       method: xpath
       pattern: //meta[@name='PublishDate']/@content
-    rnews_date_published: &rnews_date_published
+    rnews_date_published: &rnews_date_published_datetime
       method: xpath
       pattern: //meta[@property='rnews:datePublished']/@content
-    sailthru_date: &sailthru_date
+    sailthru_date: &sailthru_date_datetime
       method: xpath
       pattern: //meta[@name='sailthru.date']/@content
   title:
@@ -104,13 +104,13 @@ domains:
     description: *og_description
     keywords: *meta_keywords
     section: *meta_section
-    datetime: *article_published_time
+    datetime: *article_published_time_datetime
     title: *og_title
   fool.com:
     author: *meta_author
-    body: *readability
+    body: *readability_body
     description: *meta_description
-    keywords: *article_tag
+    keywords: *article_tag_keywords
     section: *meta_section
-    datetime: *date
+    datetime: *date_datetime
     title: *og_title

--- a/lib/news_scraper/trainer/preset_selector.rb
+++ b/lib/news_scraper/trainer/preset_selector.rb
@@ -29,7 +29,7 @@ module NewsScraper
 
         selected_index = pattern_options[selected_option]
         selected_preset_code = transform_results[selected_index].first
-        @data_type_presets[selected_preset_code]
+        @data_type_presets[selected_preset_code].merge('variable' => [selected_preset_code, @data_type].join('_'))
       end
 
       private

--- a/lib/news_scraper/trainer/uri_trainer.rb
+++ b/lib/news_scraper/trainer/uri_trainer.rb
@@ -46,9 +46,25 @@ module NewsScraper
       end
 
       def save_selected_presets(selected_presets)
-        article_scrape_patterns['domains'][@root_domain] = selected_presets
-        File.write(Constants::SCRAPE_PATTERN_FILEPATH, article_scrape_patterns.to_yaml)
+        current_content = File.read(Constants::SCRAPE_PATTERN_FILEPATH).chomp
+        new_content = "#{current_content}\n#{build_domain_yaml(selected_presets)}\n"
+
+        File.write(Constants::SCRAPE_PATTERN_FILEPATH, new_content)
         CLI.log("Successfully wrote presets for #{@root_domain} to #{Constants::SCRAPE_PATTERN_FILEPATH}.")
+      end
+
+      def build_domain_yaml(selected_presets)
+        spacer = "  "
+        output_string = ["#{spacer}#{@root_domain}:"]
+        selected_presets.each do |data_type, spec|
+          if spec.include?('variable')
+            output_string << (spacer * 2) + "#{data_type}: *#{spec['variable']}"
+          else
+            output_string << (spacer * 2) + "#{data_type}:"
+            spec.each { |k, v| output_string << (spacer * 3) + "#{k}: #{v}" }
+          end
+        end
+        output_string.join("\n")
       end
 
       def article_scrape_patterns

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,5 +16,21 @@ module MiniTest
     def transformation_fixture(domain)
       YAML.load_file("test/data/articles/#{domain.tr('.', '_')}_transformed.yml")
     end
+
+    def temporary_scrape_patterns_test
+      original_content = File.read(NewsScraper::Constants::SCRAPE_PATTERN_FILEPATH)
+      # Use a tmp dir so as not to override the actual config/article_scrape_patterns.yml
+      Dir.mktmpdir do |dir|
+        config_path = File.join(dir, NewsScraper::Constants::SCRAPE_PATTERN_FILEPATH)
+        FileUtils.mkpath(File.dirname(config_path))
+
+        Dir.chdir(dir) do
+          File.write(config_path, original_content)
+          capture_subprocess_io do
+            yield(config_path)
+          end
+        end
+      end
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,17 +17,17 @@ module MiniTest
       YAML.load_file("test/data/articles/#{domain.tr('.', '_')}_transformed.yml")
     end
 
-    def temporary_scrape_patterns_test
-      original_content = File.read(NewsScraper::Constants::SCRAPE_PATTERN_FILEPATH)
+    def stub_temp_file_with_path(file_path)
+      original_content = File.read(file_path)
       # Use a tmp dir so as not to override the actual config/article_scrape_patterns.yml
       Dir.mktmpdir do |dir|
-        config_path = File.join(dir, NewsScraper::Constants::SCRAPE_PATTERN_FILEPATH)
-        FileUtils.mkpath(File.dirname(config_path))
+        temp_path = File.join(dir, file_path)
+        FileUtils.mkpath(File.dirname(temp_path))
 
         Dir.chdir(dir) do
-          File.write(config_path, original_content)
+          File.write(temp_path, original_content)
           capture_subprocess_io do
-            yield(config_path)
+            yield(temp_path)
           end
         end
       end

--- a/test/unit/config/xpath_css_path_test.rb
+++ b/test/unit/config/xpath_css_path_test.rb
@@ -6,23 +6,6 @@ class XpathCssPathTest < Minitest::Test
     @presets = @scrape_patterns['presets']
   end
 
-  def test_all_valid_methods_are_tested
-    # all instance methods for this class, other than this test method
-    # and the assert_methods_spec should be methods that test presets
-    methods = self.class.instance_methods - Minitest::Test.instance_methods - [__method__, :assert_matches_spec]
-    expected_methods = @presets.flat_map do |preset, specs|
-      specs.collect do |spec_name, spec|
-        ['test', preset, spec_name].join('_') if %w(xpath css).include?(spec['method'])
-      end.compact
-    end
-
-    expected_methods.each do |expected_method|
-      _, preset, pattern = expected_method.split('_')
-      assert methods.include?(expected_method.to_sym),
-        " preset=#{preset} // pattern=#{pattern} was not tested, make sure to test it"
-    end
-  end
-
   def test_author_class
     assert_matches_spec(
       spec: @presets['author']['class'],

--- a/test/unit/trainers/preset_selector_test.rb
+++ b/test/unit/trainers/preset_selector_test.rb
@@ -55,7 +55,10 @@ module NewsScraper
           data_type: @target_data_type
         )
 
-        assert_equal(NewsScraper::Constants::SCRAPE_PATTERNS['presets']['description']['og'], preset.select)
+        assert_equal(
+          NewsScraper::Constants::SCRAPE_PATTERNS['presets']['description']['og'].merge("variable" => "og_description"),
+          preset.select
+        )
       end
     end
   end

--- a/test/unit/trainers/uri_trainer_test.rb
+++ b/test/unit/trainers/uri_trainer_test.rb
@@ -21,13 +21,13 @@ module NewsScraper
           'title' => { 'pattern_mock' => 'pattern_mock' }
         }
 
-        temporary_scrape_patterns_test do |config_path|
+        stub_temp_file_with_path(NewsScraper::Constants::SCRAPE_PATTERN_FILEPATH) do |config_path|
           Trainer::UriTrainer.new('yolo.com').train
           assert_equal expected_patterns, YAML.load_file(config_path)['domains']['yolo.com']
         end
       end
 
-      def test_train_with_variables_associates_to_the_correct_yaml_variable
+      def test_train_will_append_with_correct_yaml_anchors
         PresetSelector.any_instance.stubs(:select).returns('variable' => 'link_author')
         expected_output = <<EOF
   yolo.com:
@@ -39,7 +39,7 @@ module NewsScraper
     datetime: *link_author
     title: *link_author
 EOF
-        temporary_scrape_patterns_test do |config_path|
+        stub_temp_file_with_path(NewsScraper::Constants::SCRAPE_PATTERN_FILEPATH) do |config_path|
           Trainer::UriTrainer.new('yolo.com').train
           assert_equal expected_output, File.readlines(config_path).last(expected_output.count("\n")).join
         end

--- a/test/unit/trainers/uri_trainer_test.rb
+++ b/test/unit/trainers/uri_trainer_test.rb
@@ -10,30 +10,38 @@ module NewsScraper
       end
 
       def test_train
-        PresetSelector.any_instance.stubs(:select).returns('pattern_mock')
+        PresetSelector.any_instance.stubs(:select).returns('pattern_mock' => 'pattern_mock')
         expected_patterns = {
-          'author' => 'pattern_mock',
-          'body' => 'pattern_mock',
-          'description' => 'pattern_mock',
-          'keywords' => 'pattern_mock',
-          'section' => 'pattern_mock',
-          'datetime' => 'pattern_mock',
-          'title' => 'pattern_mock'
+          'author' => { 'pattern_mock' => 'pattern_mock' },
+          'body' => { 'pattern_mock' => 'pattern_mock' },
+          'description' => { 'pattern_mock' => 'pattern_mock' },
+          'keywords' => { 'pattern_mock' => 'pattern_mock' },
+          'section' => { 'pattern_mock' => 'pattern_mock' },
+          'datetime' => { 'pattern_mock' => 'pattern_mock' },
+          'title' => { 'pattern_mock' => 'pattern_mock' }
         }
 
-        # Use a tmp dir so as not to override the actual config/article_scrape_patterns.yml
-        Dir.mktmpdir do |dir|
-          config_path = File.join(dir, Constants::SCRAPE_PATTERN_FILEPATH)
-          FileUtils.mkpath(File.dirname(config_path))
+        temporary_scrape_patterns_test do |config_path|
+          Trainer::UriTrainer.new('yolo.com').train
+          assert_equal expected_patterns, YAML.load_file(config_path)['domains']['yolo.com']
+        end
+      end
 
-          Dir.chdir(dir) do
-            File.write(config_path, Constants::SCRAPE_PATTERNS.to_yaml)
-
-            capture_subprocess_io do
-              Trainer::UriTrainer.new('yolo.com').train
-              assert_equal expected_patterns, YAML.load_file(config_path)['domains']['yolo.com']
-            end
-          end
+      def test_train_with_variables_associates_to_the_correct_yaml_variable
+        PresetSelector.any_instance.stubs(:select).returns('variable' => 'link_author')
+        expected_output = <<EOF
+  yolo.com:
+    author: *link_author
+    body: *link_author
+    description: *link_author
+    keywords: *link_author
+    section: *link_author
+    datetime: *link_author
+    title: *link_author
+EOF
+        temporary_scrape_patterns_test do |config_path|
+          Trainer::UriTrainer.new('yolo.com').train
+          assert_equal expected_output, File.readlines(config_path).last(expected_output.count("\n")).join
         end
       end
 


### PR DESCRIPTION
## Problem
- Psych YAML parsing will replace comments and variable names, changing something like `&class_author` into `&1`
- :(
## Fix
- In the Preset Selector, pass back the pattern and the standardized variable name if there is one.
- Hand craft valid YAML for a domain (this assumes domains remain at the end of course, which I think is valid)
- Standardize on the pattern that seemed to be there `presetType_dataType`
- Write a test that validates the variable names match this standard

cc @richardwu 
