### PR TITLE
Scraper class

### DIFF
--- a/lib/news_scraper.rb
+++ b/lib/news_scraper.rb
@@ -15,6 +15,8 @@ require 'news_scraper/extractors/article'
 
 require 'news_scraper/transformers/article'
 
+require 'news_scraper/scraper'
+
 require 'news_scraper/cli'
 require 'news_scraper/trainer'
 

--- a/lib/news_scraper/scraper.rb
+++ b/lib/news_scraper/scraper.rb
@@ -1,0 +1,23 @@
+module NewsScraper
+  class Scraper
+    def initialize(query:)
+      @query = query
+    end
+
+    def scrape
+      article_urls = Extractors::GoogleNewsRss.new(query: @query).extract
+
+      transformed_articles = []
+      article_urls.each do |article_url|
+        payload = Extractors::Article.new(url: article_url).extract
+
+        transformed_article = Transformers::Article.new(uri: article_url, payload: payload).transform
+        transformed_articles << transformed_article
+
+        yield transformed_article if block_given?
+      end
+
+      transformed_articles
+    end
+  end
+end

--- a/test/unit/scraper_test.rb
+++ b/test/unit/scraper_test.rb
@@ -6,14 +6,14 @@ module NewsScraper
       NewsScraper::Extractors::GoogleNewsRss.any_instance.expects(:extract).returns(['somearticle.com/shopify'])
       NewsScraper::Extractors::Article.any_instance.expects(:extract).returns('some payload')
       @transformed_data = {
-       author: 'Richard Wu',
-       body: 'Shopify is the greatest! 10/10 would recommend',
-       description: 'Shopify is the greatest!',
-       keywords: 'shopify,greatest',
-       section: 'Technology',
-       datetime: '1997-02-06T12:00:00+00:00:00',
-       title: 'Shopify is Great',
-       root_domain: 'somearticle.com'
+        author: 'Richard Wu',
+        body: 'Shopify is the greatest! 10/10 would recommend',
+        description: 'Shopify is the greatest!',
+        keywords: 'shopify,greatest',
+        section: 'Technology',
+        datetime: '1997-02-06T12:00:00+00:00:00',
+        title: 'Shopify is Great',
+        root_domain: 'somearticle.com'
       }
       NewsScraper::Transformers::Article.any_instance.expects(:transform).returns(@transformed_data)
 
@@ -35,7 +35,7 @@ module NewsScraper
     end
 
     def test_scrape_also_returns_array_of_transformed_articles_if_block_is_given
-      assert_equal [@transformed_data],  @scraper.scrape { |_| }
+      assert_equal [@transformed_data], @scraper.scrape { |_| }
     end
   end
 end

--- a/test/unit/scraper_test.rb
+++ b/test/unit/scraper_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+module NewsScraper
+  class ScraperTest < Minitest::Test
+    def setup
+      NewsScraper::Extractors::GoogleNewsRss.any_instance.expects(:extract).returns(['somearticle.com/shopify'])
+      NewsScraper::Extractors::Article.any_instance.expects(:extract).returns('some payload')
+      @transformed_data = {
+       author: 'Richard Wu',
+       body: 'Shopify is the greatest! 10/10 would recommend',
+       description: 'Shopify is the greatest!',
+       keywords: 'shopify,greatest',
+       section: 'Technology',
+       datetime: '1997-02-06T12:00:00+00:00:00',
+       title: 'Shopify is Great',
+       root_domain: 'somearticle.com'
+      }
+      NewsScraper::Transformers::Article.any_instance.expects(:transform).returns(@transformed_data)
+
+      @scraper = NewsScraper::Scraper.new(query: 'shopify')
+    end
+
+    def test_scrape_returns_an_array_of_data_if_no_block_is_given
+      assert_equal [@transformed_data], @scraper.scrape
+    end
+
+    def test_scrape_yields_each_transformed_article_if_block_is_given
+      yielded_articles = []
+      @scraper.scrape do |transformed_article|
+        yielded_articles << transformed_article
+      end
+
+      assert_equal 1, yielded_articles.count
+      assert_equal @transformed_data, yielded_articles.first
+    end
+
+    def test_scrape_also_returns_array_of_transformed_articles_if_block_is_given
+      assert_equal [@transformed_data],  @scraper.scrape { |_| }
+    end
+  end
+end

--- a/train.rb
+++ b/train.rb
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-#
-require "bundler/setup"
-require "news_scraper"
-require 'pry'
-
-NewsScraper.train(query: ARGV[0])


### PR DESCRIPTION
Final piece of the puzzle.

User can now use e.g.

```
NewsScraper::Scraper.new(query: 'shopify').scrape
```

to get the transformed data for all Shopify articles.

cc: @jules2689 
