### PR TITLE
Separate Transformers::Article into Scraper and Trainer

### DIFF
--- a/lib/news_scraper.rb
+++ b/lib/news_scraper.rb
@@ -14,6 +14,7 @@ require 'news_scraper/extractors/google_news_rss'
 require 'news_scraper/extractors/article'
 
 require 'news_scraper/transformers/article'
+require 'news_scraper/transformers/trainer_article'
 
 require 'news_scraper/scraper'
 

--- a/lib/news_scraper/errors.rb
+++ b/lib/news_scraper/errors.rb
@@ -4,10 +4,11 @@ module NewsScraper
 
   module Transformers
     class ScrapePatternNotDefined < StandardError
-      attr_reader :root_domain
+      attr_reader :root_domain, :uri
 
       def initialize(opts = {})
         @root_domain = opts[:root_domain]
+        @uri = opts[:uri]
         super
       end
     end

--- a/lib/news_scraper/trainer/preset_selector.rb
+++ b/lib/news_scraper/trainer/preset_selector.rb
@@ -56,7 +56,7 @@ module NewsScraper
         scrape_details = blank_scrape_details
         @results ||= @data_type_presets.each_with_object({}) do |(preset_name, preset_details), hash|
           scrape_details[@data_type] = preset_details
-          train_transformer = Transformers::Article.new(
+          train_transformer = Transformers::TrainerArticle.new(
             url: @url,
             payload: @payload,
             scrape_details: scrape_details,

--- a/lib/news_scraper/transformers/article.rb
+++ b/lib/news_scraper/transformers/article.rb
@@ -6,23 +6,17 @@ require 'htmlbeautifier'
 module NewsScraper
   module Transformers
     class Article
-      attr_reader :uri, :payload
-
       # Initialize a Article object
       #
       # *Params*
       # - <code>url</code>: keyword arg - the url on which scraping was done
       # - <code>payload</code>: keyword arg - the result of the scrape
-      # - <code>scrape_details</code>: keyword arg - The pattern/methods for the domain to use in the transformation
-      # - <code>scrape_patterns</code>: keyword arg - The patterns available to use in transformation
       #
-      def initialize(url:, payload:, scrape_details: nil, scrape_patterns: Constants::SCRAPE_PATTERNS)
+      def initialize(url:, payload:)
         uri_parser = URIParser.new(url)
         @uri = uri_parser.without_scheme
         @root_domain = uri_parser.host
         @payload = payload
-        @scrape_patterns = scrape_patterns
-        @scrape_details = scrape_details
       end
 
       # Transform the article
@@ -34,7 +28,7 @@ module NewsScraper
       # - <code>transformed_response</code>: the response that has been parsed and transformed to a hash
       #
       def transform
-        raise ScrapePatternNotDefined.new(root_domain: @root_domain) unless scrape_details
+        raise ScrapePatternNotDefined.new(uri: @uri, root_domain: @root_domain) unless scrape_details
 
         transformed_response.merge(uri: @uri, root_domain: @root_domain)
       end
@@ -42,11 +36,11 @@ module NewsScraper
       private
 
       def scrape_details
-        @scrape_details ||= @scrape_patterns['domains'][@root_domain]
+        @scrape_details ||= Constants::SCRAPE_PATTERNS['domains'][@root_domain]
       end
 
       def transformed_response
-        @scrape_patterns['data_types'].each_with_object({}) do |data_type, response|
+        Constants::SCRAPE_PATTERNS['data_types'].each_with_object({}) do |data_type, response|
           response[data_type.to_sym] = parsed_data(data_type)
         end
       end
@@ -57,12 +51,12 @@ module NewsScraper
         scrape_method = scrape_details[data_type]['method'].to_sym
         case scrape_method
         when :xpath
-          noko_html = Nokogiri::HTML(payload)
+          noko_html = Nokogiri::HTML(@payload)
           Sanitize.fragment(
             noko_html.send(scrape_method, "(#{scrape_details[data_type]['pattern']})[1]")
           ).squish
         when :css
-          noko_html = Nokogiri::HTML(payload)
+          noko_html = Nokogiri::HTML(@payload)
           Sanitize.fragment(
             noko_html.send(scrape_method, scrape_details[data_type]['pattern'])
           ).squish

--- a/lib/news_scraper/transformers/trainer_article.rb
+++ b/lib/news_scraper/transformers/trainer_article.rb
@@ -1,0 +1,17 @@
+module NewsScraper
+  module Transformers
+    class TrainerArticle < Article
+      # Initialize a TrainerArticle object
+      #
+      # *Params*
+      # - <code>url</code>: keyword arg - the url on which scraping was done
+      # - <code>payload</code>: keyword arg - the result of the scrape
+      # - <code>scrape_details</code>: keyword arg - The pattern/methods for the domain to use in the transformation
+      #
+      def initialize(url:, payload:, scrape_details:)
+        @scrape_details = scrape_details
+        super(url: url, payload: payload)
+      end
+    end
+  end
+end

--- a/test/unit/trainer/url_trainer_test.rb
+++ b/test/unit/trainer/url_trainer_test.rb
@@ -5,7 +5,7 @@ module NewsScraper
     class UrlTrainerTest < Minitest::Test
       def setup
         super
-        Transformers::Article.any_instance.stubs(:transform)
+        Transformers::TrainerArticle.any_instance.stubs(:transform)
         Extractors::Article.any_instance.stubs(:extract)
       end
 

--- a/test/unit/transformers/article_test.rb
+++ b/test/unit/transformers/article_test.rb
@@ -17,12 +17,14 @@ class ArticleTest < Minitest::Test
   end
 
   def test_transform_raises_scrape_pattern_not_defined_for_unsupported_domain
+    unsupported_url = 'unsupported-domain.com/article'
     unsupported_domain = 'unsupported-domain.com'
-    transformer = NewsScraper::Transformers::Article.new(url: unsupported_domain, payload: '')
+    transformer = NewsScraper::Transformers::Article.new(url: unsupported_url, payload: '')
 
     err = assert_raises NewsScraper::Transformers::ScrapePatternNotDefined do
       transformer.transform
     end
+    assert_equal unsupported_url, err.uri
     assert_equal unsupported_domain, err.root_domain
   end
 end

--- a/test/unit/transformers/trainer_article_test.rb
+++ b/test/unit/transformers/trainer_article_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class TrainerArticleTest < Minitest::Test
+  def test_transform_returns_correct_json_transformation_for_supported_domains
+    supported_domains = NewsScraper::Constants::SCRAPE_PATTERNS['domains'].keys
+
+    supported_domains.each do |domain|
+      raw_data = raw_data_fixture(domain)
+      transformer = NewsScraper::Transformers::TrainerArticle.new(
+        url: "#{domain}/some_article",
+        payload: raw_data,
+        scrape_details: NewsScraper::Constants::SCRAPE_PATTERNS['domains'][domain]
+      )
+
+      expected_transformation = transformation_fixture(domain)
+      # Yaml has a hard time with new lines on a multi-line string
+      expected_transformation.map { |_, v| v.strip! }
+
+      assert_equal expected_transformation, transformer.transform
+    end
+  end
+end


### PR DESCRIPTION
Key note:
- Abstracted common methods (everything but constructor) into a `Transformers::Article` module
- Created a `Transformers::ScraperArticle` and `Transformers::TrainerArticle` class

Would inheritance be better here? 

cc: @jules2689 
