### PR TITLE
Remove unused option in google news rss

### DIFF
--- a/lib/news_scraper/constants.rb
+++ b/lib/news_scraper/constants.rb
@@ -1,6 +1,5 @@
 module NewsScraper
   module Constants
-    TEMP_DIRS = YAML.load_file(File.expand_path('../../../config/temp_dirs.yml', __FILE__))
     SCRAPE_PATTERN_FILEPATH = File.expand_path('../../../config/article_scrape_patterns.yml', __FILE__)
     SCRAPE_PATTERNS = YAML.load_file(SCRAPE_PATTERN_FILEPATH)
   end

--- a/lib/news_scraper/extractors/google_news_rss.rb
+++ b/lib/news_scraper/extractors/google_news_rss.rb
@@ -7,7 +7,7 @@ module NewsScraper
       include ExtractorsHelpers
 
       BASE_URL = 'https://news.google.com/news?cf=all&hl=en&pz=1&ned=us&output=rss'.freeze
-      def initialize(query:, temp_write: false)
+      def initialize(query:)
         @query = query
       end
 

--- a/lib/news_scraper/extractors/google_news_rss.rb
+++ b/lib/news_scraper/extractors/google_news_rss.rb
@@ -7,21 +7,14 @@ module NewsScraper
       include ExtractorsHelpers
 
       BASE_URL = 'https://news.google.com/news?cf=all&hl=en&pz=1&ned=us&output=rss'.freeze
-      ARTICLE_URLS_DIR = Constants::TEMP_DIRS['extractors']['google_news_rss']['article_urls'].freeze
-
       def initialize(query:, temp_write: false)
         @query = query
-        @temp_write = temp_write
       end
 
       def extract
         http_request "#{BASE_URL}&q=#{@query}" do |response|
           google_urls = google_urls_from_resp(response.body)
-          article_urls = extract_article_urls(google_urls)
-
-          write_to_temp(article_urls) if @temp_write
-
-          article_urls
+          extract_article_urls(google_urls)
         end
       end
 
@@ -42,14 +35,6 @@ module NewsScraper
           regex = google_url.match(%r{&url=(?<url>https?://.*)})
           regex.nil? ? nil : regex['url']
         end.compact.uniq
-      end
-
-      def write_to_temp(article_urls)
-        filename = "#{@query.downcase.gsub(/\s/, '_')}_#{Time.now.to_i}.txt"
-        puts "Writing article urls to #{filename}"
-        File.open(File.join(ARTICLE_URLS_DIR, filename), 'w') do |file|
-          article_urls.each { |url| file.puts url }
-        end
       end
     end
   end

--- a/test/unit/extractors/google_news_rss_test.rb
+++ b/test/unit/extractors/google_news_rss_test.rb
@@ -19,20 +19,6 @@ module NewScraper
           assert_equal @expected_article_urls, @extractor.extract.sort
         end
       end
-
-      def test_extract_writes_to_file_of_extracted_article_urls
-        capture_subprocess_io do
-          Timecop.freeze do
-            expected_filename = "#{@query}_#{Time.now.to_i}.txt"
-            expected_path = File.join(NewsScraper::Extractors::GoogleNewsRss::ARTICLE_URLS_DIR, expected_filename)
-            file_handle = mock
-            file_handle.stubs(:puts)
-            File.expects(:open).with(expected_path, 'w').yields(file_handle)
-
-            NewsScraper::Extractors::GoogleNewsRss.new(query: @query, temp_write: true).extract
-          end
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
Removes unused `write_temp` option

cc @richardwu 
