### PR TITLE
Split TrainerArticle up better

### DIFF
--- a/lib/news_scraper/configuration.rb
+++ b/lib/news_scraper/configuration.rb
@@ -1,8 +1,7 @@
 module NewsScraper
   class Configuration
     DEFAULT_SCRAPE_PATTERNS_FILEPATH = File.expand_path('../../../config/article_scrape_patterns.yml', __FILE__)
-    attr_accessor :scrape_patterns_filepath
-    attr_reader :scrape_patterns
+    attr_accessor :scrape_patterns_filepath, :scrape_patterns
 
     def initialize
       self.scrape_patterns_filepath = DEFAULT_SCRAPE_PATTERNS_FILEPATH

--- a/lib/news_scraper/trainer/preset_selector.rb
+++ b/lib/news_scraper/trainer/preset_selector.rb
@@ -1,5 +1,3 @@
-require 'terminal-table'
-
 module NewsScraper
   module Trainer
     class PresetSelector
@@ -38,6 +36,7 @@ module NewsScraper
       private
 
       def pattern_options(data_type)
+        require 'terminal-table'
         # Add valid options from the transformed results
         options = transform_results[data_type].each_with_object({}) do |(option, details), valid_options|
           next unless details['data'] && !details['data'].empty?

--- a/lib/news_scraper/trainer/url_trainer.rb
+++ b/lib/news_scraper/trainer/url_trainer.rb
@@ -20,7 +20,6 @@ module NewsScraper
         NewsScraper.configuration.scrape_patterns['data_types'].each do |data_type|
           selected_presets[data_type] = selected_pattern(data_type)
         end
-
         save_selected_presets(selected_presets)
       end
 
@@ -28,21 +27,18 @@ module NewsScraper
 
       def selected_pattern(data_type)
         CLI.put_header("Determining information for #{data_type}")
-        data_type_presets = NewsScraper.configuration.scrape_patterns['presets'][data_type]
-        pattern = if data_type_presets.nil?
+        pattern = if NewsScraper.configuration.scrape_patterns['presets'][data_type].nil?
           CLI.log("No presets were found for #{data_type}. Skipping to next.")
-          nil
+          selected_presets[data_type] = nil
         else
-          PresetSelector.new(
-            url: @url,
-            payload: @payload,
-            data_type_presets: data_type_presets,
-            data_type: data_type
-          ).select
+          preset_selector.select(data_type)
         end
         CLI.put_footer
-
         pattern || { 'method' => "<<<<< TODO >>>>>", 'pattern' => "<<<<< TODO >>>>>" }
+      end
+
+      def preset_selector
+        @preset_selector ||= PresetSelector.new(url: @url, payload: @payload)
       end
 
       def save_selected_presets(selected_presets)

--- a/lib/news_scraper/transformers/trainer_article.rb
+++ b/lib/news_scraper/transformers/trainer_article.rb
@@ -6,11 +6,25 @@ module NewsScraper
       # *Params*
       # - <code>url</code>: keyword arg - the url on which scraping was done
       # - <code>payload</code>: keyword arg - the result of the scrape
-      # - <code>scrape_details</code>: keyword arg - The pattern/methods for the domain to use in the transformation
       #
-      def initialize(url:, payload:, scrape_details:)
-        @scrape_details = scrape_details
+      def initialize(url:, payload:)
         super(url: url, payload: payload)
+      end
+
+      # Transform the article
+      #
+      # *Returns*
+      # - <code>transformed_response</code>: tries all possible presets and returns a hash representing the results
+      #
+      def transform
+        presets = NewsScraper.configuration.scrape_patterns['presets']
+        transformed_response = presets.each_with_object({}) do |(data_type, preset_options), response|
+          response[data_type] = preset_options.each_with_object({}) do |(option, scrape_details), data_type_options|
+            data = parsed_data(scrape_details['method'].to_sym, scrape_details['pattern'])
+            data_type_options[option] = scrape_details.merge('data' => data)
+          end
+        end
+        transformed_response.merge('uri' => @uri, 'root_domain' => @root_domain)
       end
     end
   end

--- a/news_scraper.gemspec
+++ b/news_scraper.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'timecop', '~> 0.8', '>= 0.8.0'
   spec.add_development_dependency 'rubocop', '~> 0.42', '>= 0.42.0'
   spec.add_development_dependency 'rdoc', '~> 4.2', '>= 4.2.2'
+  spec.add_development_dependency 'terminal-table'
 end

--- a/test/data/articles/trainer_investors_com_transformed.yml
+++ b/test/data/articles/trainer_investors_com_transformed.yml
@@ -1,0 +1,128 @@
+author:
+  class:
+    method: css
+    pattern: ".author"
+    data: BRIAN DEAGON BRIAN DEAGON | [email protected]/* &lt;![CDATA[ */!function(t,e,r,n,c,a,p){try{t=document.currentScript||function(){for(t=document.getElementsByTagName('script'),e=t.length;e--;)if(t[e].getAttribute('data-cfhash'))return
+      t[e]}();if(t&amp;&amp;(c=t.previousSibling)){p=t.parentNode;if(a=c.getAttribute('data-cfemail')){for(e='',r='0x'+a.substr(0,2)|0,n=2;a.length-n;n+=2)e+='%'+('0'+('0x'+a.substr(n,2)^r).toString(16)).slice(-2);p.replaceChild(document.createTextNode(decodeURIComponent(e)),c)}p.removeChild(t)}}catch(u){}}()/*
+      ]]&gt; */ | @IBD_BDeagon
+  id:
+    method: css
+    pattern: "#author"
+    data: ''
+  name:
+    method: css
+    pattern: ".author-name"
+    data: ''
+  link:
+    method: xpath
+    pattern: "//a[contains(@href, 'author')]"
+    data: BRIAN DEAGON
+  meta:
+    method: xpath
+    pattern: "//meta[@name='author']/@content"
+    data: ''
+  rel_link:
+    method: xpath
+    pattern: "//a[@rel='author']"
+    data: BRIAN DEAGON
+  vcard:
+    method: css
+    pattern: ".vcard .fn"
+    data: ''
+body:
+  readability:
+    method: readability
+    pattern: ''
+    data: |-
+      <div>
+        <div>
+          <p>Shopify (<a href="">SHOP</a>) received a price target increase based on expectations that the e-commerce company's price increase on premium tiers could provide an upside to earnings estimates.</p>
+          <p>Pacific Crest Securities analyst Monika Garg raised her price target on Shopify to 43 from 40, writing in a research note late Sunday that Shopify has growth opportunities ahead.</p>
+          <p>"We believe Shopify is one of the best ways to invest in e-commerce growth," wrote Garg. "Given the company's ample growth opportunities, Shopify warrants a premium valuation, in our view."</p>
+          <p>Shopify stock climbed 9% on Aug. 3 after it reported Q2 earnings that showed a 93% jump in revenue to $86.7 million, year over year, topping views. The company also reported a wider loss, but that still beat analyst expectations.</p>
+          <p>Shopify says 53% of merchant orders were made via mobile devices in Q2. It said more than 300,000 small and medium-sized businesses use its e-commerce platform, up from 175,000 in the year-earlier period.</p>
+          <p>Shopify shares rose 0.2% to 42.49 in the stock market today.</p>
+          <p>IBD'S TAKE:  Shopify is extended beyond its buy point of 31.52 touched on July 11. It has a solid Relative Strength Rating of 79, meaning the stock has outperformed 79% of stocks in the past year. The RS is one way IBD can help investors find and evaluate stocks.</p>
+          <p>Merchants use Shopify's software to support sales channels over the web, mobile devices, social media and retail outlets.  Shopify targets businesses and other enterprises with less than 500 employees. Garg says there are 10 million such businesses, which she says means Shopify's penetration rate is in the low single digits for a total addressable market near $10 billion.</p>
+          <p>RELATED:</p>
+          <p>How Amazon, Microsoft Can Unlock Small-Business Market For SaaS</p>
+        </div>
+      </div>
+description:
+  meta:
+    method: xpath
+    pattern: "//meta[@name='description']/@content"
+    data: Shopify's price increase on premium tiers could provide an upside to earnings
+      estimates, an analyst said in hiking her price target.
+  og:
+    method: xpath
+    pattern: "//meta[@property='og:description']/@content"
+    data: Shopify's price increase on premium tiers could provide an upside to earnings
+      estimates, an analyst said in hiking her price target.
+keywords:
+  meta:
+    method: xpath
+    pattern: "//meta[@name='keywords']/@content"
+    data: shopify news,analyst reports on shopify. e-commerce companies,shopify earnings
+  article_tag:
+    method: xpath
+    pattern: "//meta[@property='article:tag']/@content"
+    data: ''
+section:
+  meta:
+    method: xpath
+    pattern: "//meta[@property='article:section']/@content"
+    data: Technology
+datetime:
+  article_date_original:
+    method: xpath
+    pattern: "//meta[@name='article_date_original']/@content"
+    data: ''
+  article_published_time:
+    method: xpath
+    pattern: "//meta[@property='article:published_time']/@content"
+    data: '2016-08-22T13:09:14+00:00'
+  date:
+    method: xpath
+    pattern: "//meta[@name='date']/@content"
+    data: 2016-08-22 13:09:14:-08:00
+  date_published:
+    method: xpath
+    pattern: "//*[@itemprop='datePublished']/@datetime"
+    data: ''
+  og_published_time:
+    method: xpath
+    pattern: "//meta[@property='og:published_time']/@content"
+    data: ''
+  original_publication_date:
+    method: xpath
+    pattern: "//meta[@name='OriginalPublicationDate']/@content"
+    data: ''
+  publication_date:
+    method: xpath
+    pattern: "//meta[@name='publication_date']/@content"
+    data: ''
+  publish_date:
+    method: xpath
+    pattern: "//meta[@name='PublishDate']/@content"
+    data: ''
+  rnews_date_published:
+    method: xpath
+    pattern: "//meta[@property='rnews:datePublished']/@content"
+    data: ''
+  sailthru_date:
+    method: xpath
+    pattern: "//meta[@name='sailthru.date']/@content"
+    data: ''
+title:
+  html:
+    method: xpath
+    pattern: "//title"
+    data: Shopify Price Target Increased, Supported By Upside To Earnings | Stock
+      News &amp; Stock Market Analysis - IBD
+  og:
+    method: xpath
+    pattern: "//meta[@property='og:title']/@content"
+    data: Why Shopify Stock Deserves 'Premium Valuation,' Says Pacific Crest
+uri: investors.com/some_article
+root_domain: investors.com

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,6 @@ module MiniTest
   class Test
     def setup
       super
-
       NewsScraper.reset_configuration
       FileUtils.touch(scrape_patterns_path)
       File.write(scrape_patterns_path, NewsScraper.configuration.scrape_patterns.to_yaml)
@@ -32,6 +31,10 @@ module MiniTest
 
     def raw_data_fixture(domain)
       File.read("test/data/articles/#{domain.tr('.', '_')}_raw")
+    end
+
+    def trainer_transformation_fixture(domain)
+      YAML.load_file("test/data/articles/trainer_#{domain.tr('.', '_')}_transformed.yml")
     end
 
     def transformation_fixture(domain)

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -21,6 +21,13 @@ module NewsScraper
       end
     end
 
+    def test_setting_scrape_patterns_directly
+      NewsScraper.configure do |config|
+        config.scrape_patterns = { "banana" => "kiwi" }
+      end
+      assert_equal({ "banana" => "kiwi" }, NewsScraper.configuration.scrape_patterns)
+    end
+
     def test_scrape_patterns_loaded_from_filepath
       assert_equal(@tmp_file.path, NewsScraper.configuration.scrape_patterns_filepath)
       assert_equal({ 'domains' => 'test' }, NewsScraper.configuration.scrape_patterns)

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -28,6 +28,13 @@ module NewsScraper
       assert_equal({ "banana" => "kiwi" }, NewsScraper.configuration.scrape_patterns)
     end
 
+    def test_scrape_patterns_domains_are_set
+      NewsScraper.configure do |config|
+        config.scrape_patterns['domains'] = { 'domains' => 'test' }
+      end
+      assert_equal({ 'domains' => 'test' }, NewsScraper.configuration.scrape_patterns['domains'])
+    end
+
     def test_scrape_patterns_loaded_from_filepath
       assert_equal(@tmp_file.path, NewsScraper.configuration.scrape_patterns_filepath)
       assert_equal({ 'domains' => 'test' }, NewsScraper.configuration.scrape_patterns)

--- a/test/unit/trainer/preset_selector_test.rb
+++ b/test/unit/trainer/preset_selector_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'terminal-table'
 
 module NewsScraper
   module Trainer

--- a/test/unit/transformers/trainer_article_test.rb
+++ b/test/unit/transformers/trainer_article_test.rb
@@ -3,23 +3,16 @@ require 'test_helper'
 module NewsScraper
   module Transformers
     class TrainerArticleTest < Minitest::Test
-      def test_transform_returns_correct_json_transformation_for_supported_domains
-        supported_domains = NewsScraper.configuration.scrape_patterns['domains'].keys
+      def test_transform_returns_full_preset_data
+        domain = NewsScraper.configuration.scrape_patterns['domains'].keys.first
+        raw_data = raw_data_fixture(domain)
+        transformer = NewsScraper::Transformers::TrainerArticle.new(
+          url: "#{domain}/some_article",
+          payload: raw_data
+        )
 
-        supported_domains.each do |domain|
-          raw_data = raw_data_fixture(domain)
-          transformer = NewsScraper::Transformers::TrainerArticle.new(
-            url: "#{domain}/some_article",
-            payload: raw_data,
-            scrape_details: NewsScraper.configuration.scrape_patterns['domains'][domain],
-          )
-
-          expected_transformation = transformation_fixture(domain)
-          # Yaml has a hard time with new lines on a multi-line string
-          expected_transformation.map { |_, v| v.strip! }
-
-          assert_equal expected_transformation, transformer.transform
-        end
+        expected_transformation = trainer_transformation_fixture(domain)
+        assert_equal expected_transformation, transformer.transform
       end
     end
   end


### PR DESCRIPTION
## Problem

So, upon looking to add training to the api app, I realized we had no easy way to do this. Looking at our code, I quickly realized that trainer articles and base articles should probably return different responses. Base articles know what they need, they have patterns set - trainer articles are meant to explore our presets, but we were bending it to do everything one at a time.
## Result

**Trainer Article**
- Instead, trainer article will now return a hash presenting _all_ presets available at that time. 
- It doesn't need to raise because we're training and raising is for actual scraping
- With these in mind, it makes sense to make the `parsed_data` in the super class slightly more generic and override `transform`

**Base Article**
Base Article functionality remains unchanged.

**Preset Selector**
- This also means that preset selector becomes less specialized
- It really doesn't care about scrape details, only all presets
- it cares about a data type - but only in the `select` method instead of `initialize`. 
- This means that we have a cleaner code path with less logic, as we will parse all presets that trainer returns, and allow selection by data type in `select`

In the end, we don't pass around a bunch of `scrape_details` and `data_types`. Largely, the `scrape_details` for training is useless because we end up trying all presets anyways and data type really only matters for a specific selection (but we have to select for all of them anyways, so defer that to the last call into selection).

Thankfully, this was easy due to your previous refactor to split articles @richardwu
## In the end

We can call:

```
Transformers::TrainerArticle.new(url: @url, payload: @payload).transform
```

from the api app and have all available options, present that in the UI, save to DB.

cc @richardwu 
